### PR TITLE
Fix typographical errors in Makefile

### DIFF
--- a/utils/prodos-utils/Makefile
+++ b/utils/prodos-utils/Makefile
@@ -94,8 +94,8 @@ prodos_time.o:	prodos_time.c prodos.h
 
 
 install:	
-		cp prodos mkprodosfs prodoscat text_to_prodos $(INSTALL_LOC)
+		cp prodos mkprodosfs prodos_cat text_to_prodos $(INSTALL_LOC)
 
 clean:		
-		rm -f *~ *.o prodos mkprodosfs prodoscat text_to_prodos
+		rm -f *~ *.o prodos mkprodosfs prodos_cat text_to_prodos
 


### PR DESCRIPTION
"prodos_cat" executable is erroneously referenced as "prodoscat" in "install:" and "clean:"