### PR TITLE
Dos33 exit codes

### DIFF
--- a/utils/dos33fs-utils/dos33.h
+++ b/utils/dos33fs-utils/dos33.h
@@ -67,7 +67,7 @@ int dos33_vtoc_find_free_sector(unsigned char *vtoc,
 
 /* dos33_catalog.c */
 unsigned char dos33_char_to_type(char type, int lock);
-void dos33_catalog(int dos_fd, unsigned char *vtoc);
+int dos33_catalog(int dos_fd, unsigned char *vtoc);
 char *dos33_filename_to_ascii(char *dest,unsigned char *src,int len);
 unsigned char dos33_file_type(int value);
 

--- a/utils/dos33fs-utils/dos33_catalog.c
+++ b/utils/dos33fs-utils/dos33_catalog.c
@@ -183,14 +183,18 @@ static int dos33_print_file_info(int fd,int catalog_tsf) {
 
 	printf("\n");
 
-	if (result<0) fprintf(stderr,"Error on I/O\n");
+	if (result<0) {
+		fprintf(stderr,"Error on I/O\n");
+		return -1;
+	}
 
 	return 0;
 }
 
-void dos33_catalog(int dos_fd, unsigned char *vtoc) {
+int dos33_catalog(int dos_fd, unsigned char *vtoc) {
 
 	int catalog_entry;
+	int result;
 
 	/* get first catalog */
 	catalog_entry=dos33_get_catalog_ts(vtoc);
@@ -200,11 +204,14 @@ void dos33_catalog(int dos_fd, unsigned char *vtoc) {
 		catalog_entry=dos33_find_next_file(dos_fd,catalog_entry,vtoc);
 		if (debug) fprintf(stderr,"CATALOG entry=$%X\n",catalog_entry);
 		if (catalog_entry>0) {
-			dos33_print_file_info(dos_fd,catalog_entry);
+			result=dos33_print_file_info(dos_fd,catalog_entry);
+			if (result<0) return -1;
 			/* why 1<<16 ? */
 			catalog_entry+=(1<<16);
 			/* dos33_find_next_file() handles wrapping issues */
 		}
 	}
 	printf("\n");
+
+	return 0;
 }


### PR DESCRIPTION
Intended to address #13.

Error checking was added in various places throughout dos33 code.

Notes:
- I didn't test thoroughly, but I did run the included tests (which passed), and confirmed my specific use case (from #13)
- there are a lot of repetitive checks now; I avoided some repetition with a macro in `main()`, perhaps I should have introduced an additional macro for the common "check the result of `read()` or `write()`" cases as well?
- In general I've used an exit status of `2` to indicate a problem with the way the user invoked the program, and `1` to indicate a general problem or failure. This seems to match a common Unix custom.