### PR TITLE
Initialize path string variables.

### DIFF
--- a/utils/prodos-utils/prodos.c
+++ b/utils/prodos-utils/prodos.c
@@ -1076,9 +1076,10 @@ int main(int argc, char **argv) {
 
 	int command,file_exists;
 	char temp_string[BUFSIZ];
-	char apple_filename[31],new_filename[31];
-	char apple_path[BUFSIZ];
-	char local_filename[BUFSIZ];
+	char apple_filename[31] = {};
+	char new_filename[31] = {};
+	char apple_path[BUFSIZ] = {};
+	char local_filename[BUFSIZ] = {};
 	char *result_string;
 	int always_yes=0;
 	char *temp,*endptr;


### PR DESCRIPTION
These string variables were being used uninitialized, causing me to get spurious errors due to random garbage, like:

```
$ prodos -t BIN -a 0x6000 VIMODE-PRODOS.dsk SAVE VIMODE
Error!   not found!
Error, couldn't open directory (null)
$ prodos -t BIN -a 0x6000 VIMODE-PRODOS.dsk SAVE VIMODE
Error!  9 not found!
Error, couldn't open directory (null)
$ prodos -t BIN -a 0x6000 VIMODE-PRODOS.dsk SAVE VIMODE
Error!  @ not found!
Error, couldn't open directory (null)
$
```

Et cetera. Adding {} initializers resolved the issue for me (and allowed the above command to complete successfully).

I experienced this issue on Mac OS. I did not experience this on Ubuntu, either because I was lucky, or more likely the memory was already cleared to zero before `main()` is entered.