### PR TITLE
utils/{gr,hgr}-utils/Makefile: Use pkg-config for compile/link flags

### DIFF
--- a/utils/gr-utils/Makefile
+++ b/utils/gr-utils/Makefile
@@ -1,6 +1,7 @@
 include ../../Makefile.inc
 
-CFLAGS = -g -Wall -O2
+CFLAGS = -g -Wall -O2 $(shell pkg-config --cflags libpng)
+LDFLAGS = $(shell pkg-config --libs libpng)
 
 all:	text2gr png2gr png2gr_text png2rle png2lz4 png_to_40x48d png_to_40x96 \
 	png2sixbitmap png2six80 png2sixrle png2fourrle png2sixrle2 png_16x16 \
@@ -24,7 +25,7 @@ text2gr.o:		text2gr.c
 ###
 
 png2gr:		png2gr.o loadpng.o
-	$(CC) $(LFLAGS) -o png2gr png2gr.o loadpng.o -lpng
+	$(CC) $(LFLAGS) -o png2gr png2gr.o loadpng.o $(LDFLAGS) -lpng
 
 png2gr.o:		png2gr.c loadpng.h
 	$(CC) $(CFLAGS) -c png2gr.c
@@ -32,7 +33,7 @@ png2gr.o:		png2gr.c loadpng.h
 ###
 
 png2dgr:		png2dgr.o loadpng.o
-	$(CC) $(LFLAGS) -o png2dgr png2dgr.o loadpng.o -lpng
+	$(CC) $(LFLAGS) -o png2dgr png2dgr.o loadpng.o $(LDFLAGS) -lpng
 
 png2dgr.o:		png2dgr.c loadpng.h
 	$(CC) $(CFLAGS) -c png2dgr.c
@@ -41,7 +42,7 @@ png2dgr.o:		png2dgr.c loadpng.h
 ###
 
 png2sprites:		png2sprites.o loadpng.o
-	$(CC) $(LFLAGS) -o png2sprites png2sprites.o loadpng.o -lpng
+	$(CC) $(LFLAGS) -o png2sprites png2sprites.o loadpng.o $(LDFLAGS) -lpng
 
 png2sprites.o:		png2sprites.c loadpng.h
 	$(CC) $(CFLAGS) -c png2sprites.c
@@ -50,7 +51,7 @@ png2sprites.o:		png2sprites.c loadpng.h
 ###
 
 png2gr_text:		png2gr_text.o loadpng.o
-	$(CC) $(LFLAGS) -o png2gr_text png2gr_text.o loadpng.o -lpng
+	$(CC) $(LFLAGS) -o png2gr_text png2gr_text.o loadpng.o $(LDFLAGS) -lpng
 
 png2gr_text.o:		png2gr_text.c loadpng.h
 	$(CC) $(CFLAGS) -c png2gr_text.c
@@ -58,7 +59,7 @@ png2gr_text.o:		png2gr_text.c loadpng.h
 ###
 
 png2sixbitmap:		png2sixbitmap.o loadpng.o
-	$(CC) $(LFLAGS) -o png2sixbitmap png2sixbitmap.o loadpng.o -lpng
+	$(CC) $(LFLAGS) -o png2sixbitmap png2sixbitmap.o loadpng.o $(LDFLAGS) -lpng
 
 png2sixbitmap.o:		png2sixbitmap.c loadpng.h
 	$(CC) $(CFLAGS) -c png2sixbitmap.c
@@ -66,7 +67,7 @@ png2sixbitmap.o:		png2sixbitmap.c loadpng.h
 ###
 
 png_16x16:		png_16x16.o loadpng.o
-	$(CC) $(LFLAGS) -o png_16x16 png_16x16.o loadpng.o -lpng
+	$(CC) $(LFLAGS) -o png_16x16 png_16x16.o loadpng.o $(LDFLAGS) -lpng
 
 png_16x16.o:		png_16x16.c loadpng.h
 	$(CC) $(CFLAGS) -c png_16x16.c
@@ -74,7 +75,7 @@ png_16x16.o:		png_16x16.c loadpng.h
 ###
 
 png2fourrle:		png2fourrle.o loadpng.o
-	$(CC) $(LFLAGS) -o png2fourrle png2fourrle.o loadpng.o -lpng
+	$(CC) $(LFLAGS) -o png2fourrle png2fourrle.o loadpng.o $(LDFLAGS) -lpng
 
 png2fourrle.o:		png2fourrle.c loadpng.h
 	$(CC) $(CFLAGS) -c png2fourrle.c
@@ -82,7 +83,7 @@ png2fourrle.o:		png2fourrle.c loadpng.h
 ###
 
 png2sixrle:		png2sixrle.o loadpng.o
-	$(CC) $(LFLAGS) -o png2sixrle png2sixrle.o loadpng.o -lpng
+	$(CC) $(LFLAGS) -o png2sixrle png2sixrle.o loadpng.o $(LDFLAGS) -lpng
 
 png2sixrle.o:		png2sixrle.c loadpng.h
 	$(CC) $(CFLAGS) -c png2sixrle.c
@@ -90,7 +91,7 @@ png2sixrle.o:		png2sixrle.c loadpng.h
 ###
 
 png2sixrle2:		png2sixrle2.o loadpng.o
-	$(CC) $(LFLAGS) -o png2sixrle2 png2sixrle2.o loadpng.o -lpng
+	$(CC) $(LFLAGS) -o png2sixrle2 png2sixrle2.o loadpng.o $(LDFLAGS) -lpng
 
 png2sixrle2.o:		png2sixrle2.c loadpng.h
 	$(CC) $(CFLAGS) -c png2sixrle2.c
@@ -100,7 +101,7 @@ png2sixrle2.o:		png2sixrle2.c loadpng.h
 ###
 
 png2six80:		png2six80.o loadpng.o
-	$(CC) $(LFLAGS) -o png2six80 png2six80.o loadpng.o -lpng
+	$(CC) $(LFLAGS) -o png2six80 png2six80.o loadpng.o $(LDFLAGS) -lpng
 
 png2six80.o:		png2six80.c loadpng.h
 	$(CC) $(CFLAGS) -c png2six80.c
@@ -109,7 +110,7 @@ png2six80.o:		png2six80.c loadpng.h
 ###
 
 png2rle:		png2rle.o loadpng.o rle_common.o
-	$(CC) $(LFLAGS) -o png2rle png2rle.o loadpng.o rle_common.o -lpng
+	$(CC) $(LFLAGS) -o png2rle png2rle.o loadpng.o rle_common.o $(LDFLAGS) -lpng
 
 png2rle.o:		png2rle.c loadpng.h rle_common.h
 	$(CC) $(CFLAGS) -c png2rle.c
@@ -117,7 +118,7 @@ png2rle.o:		png2rle.c loadpng.h rle_common.h
 ###
 
 png2raw:		png2raw.o loadpng.o
-	$(CC) $(LFLAGS) -o png2raw png2raw.o loadpng.o -lpng
+	$(CC) $(LFLAGS) -o png2raw png2raw.o loadpng.o $(LDFLAGS) -lpng
 
 png2raw.o:		png2raw.c loadpng.h
 	$(CC) $(CFLAGS) -c png2raw.c
@@ -127,7 +128,7 @@ png2raw.o:		png2raw.c loadpng.h
 ###
 
 png2lz4:		png2lz4.o loadpng.o
-	$(CC) $(LFLAGS) -o png2lz4 png2lz4.o loadpng.o -llz4 -lpng
+	$(CC) $(LFLAGS) -o png2lz4 png2lz4.o loadpng.o -llz4 $(LDFLAGS) -lpng
 
 png2lz4.o:		png2lz4.c loadpng.h
 	$(CC) $(CFLAGS) -c png2lz4.c
@@ -137,7 +138,7 @@ png2lz4.o:		png2lz4.c loadpng.h
 ###
 
 png_to_40x48d:		png_to_40x48d.o rle_common.o
-	$(CC) $(LFLAGS) -o png_to_40x48d png_to_40x48d.o rle_common.o -lpng
+	$(CC) $(LFLAGS) -o png_to_40x48d png_to_40x48d.o rle_common.o $(LDFLAGS) -lpng
 
 png_to_40x48d.o:		png_to_40x48d.c rle_common.h
 	$(CC) $(CFLAGS) -c png_to_40x48d.c
@@ -145,7 +146,7 @@ png_to_40x48d.o:		png_to_40x48d.c rle_common.h
 ###
 
 png_to_40x96:		png_to_40x96.o loadpng.o rle_common.o
-	$(CC) $(LFLAGS) -o png_to_40x96 png_to_40x96.o loadpng.o rle_common.o -lpng
+	$(CC) $(LFLAGS) -o png_to_40x96 png_to_40x96.o loadpng.o rle_common.o $(LDFLAGS) -lpng
 
 png_to_40x96.o:		png_to_40x96.c loadpng.h rle_common.h
 	$(CC) $(CFLAGS) -c png_to_40x96.c
@@ -153,7 +154,7 @@ png_to_40x96.o:		png_to_40x96.c loadpng.h rle_common.h
 ###
 
 gr2png:		gr2png.o
-	$(CC) $(LFLAGS) -o gr2png gr2png.o -lpng
+	$(CC) $(LFLAGS) -o gr2png gr2png.o $(LDFLAGS) -lpng
 
 gr2png.o:		gr2png.c
 	$(CC) $(CFLAGS) -c gr2png.c
@@ -161,7 +162,7 @@ gr2png.o:		gr2png.c
 ###
 
 dgr2png:		dgr2png.o
-	$(CC) $(LFLAGS) -o dgr2png dgr2png.o -lpng
+	$(CC) $(LFLAGS) -o dgr2png dgr2png.o $(LDFLAGS) -lpng
 
 dgr2png.o:		dgr2png.c
 	$(CC) $(CFLAGS) -c dgr2png.c

--- a/utils/hgr-utils/Makefile
+++ b/utils/hgr-utils/Makefile
@@ -1,6 +1,7 @@
 include ../../Makefile.inc
 
-CFLAGS = -O2 -Wall -g
+CFLAGS = -g -Wall -O2 $(shell pkg-config --cflags libpng)
+LDFLAGS = $(shell pkg-config --libs libpng)
 
 all:	pcx2hgr png2hgr png2dhgr shape_table dump_table hgr2png hgr_make_sprite
 
@@ -25,7 +26,7 @@ pcx2hgr.o:		pcx2hgr.c
 ###
 
 png2hgr:		png2hgr.o
-			$(CC) -o png2hgr png2hgr.o $(LFLAGS) -lpng
+			$(CC) -o png2hgr png2hgr.o $(LFLAGS) $(LDFLAGS) -lpng
 
 png2hgr.o:		png2hgr.c
 			$(CC) $(CFLAGS) -c png2hgr.c
@@ -33,7 +34,7 @@ png2hgr.o:		png2hgr.c
 ###
 
 hgr_make_sprite:		hgr_make_sprite.o
-			$(CC) -o hgr_make_sprite hgr_make_sprite.o $(LFLAGS) -lpng
+			$(CC) -o hgr_make_sprite hgr_make_sprite.o $(LFLAGS) $(LDFLAGS) -lpng
 
 hgr_make_sprite.o:		hgr_make_sprite.c
 			$(CC) $(CFLAGS) -c hgr_make_sprite.c
@@ -42,7 +43,7 @@ hgr_make_sprite.o:		hgr_make_sprite.c
 ###
 
 hgr2png:		hgr2png.o
-			$(CC) -o hgr2png hgr2png.o $(LFLAGS) -lpng
+			$(CC) -o hgr2png hgr2png.o $(LFLAGS) $(LDFLAGS) -lpng
 
 hgr2png.o:		hgr2png.c
 			$(CC) $(CFLAGS) -c hgr2png.c
@@ -50,7 +51,7 @@ hgr2png.o:		hgr2png.c
 ###
 
 png2dhgr:		png2dhgr.o
-			$(CC) -o png2dhgr png2dhgr.o $(LFLAGS) -lpng
+			$(CC) -o png2dhgr png2dhgr.o $(LFLAGS) $(LDFLAGS) -lpng
 
 png2dhgr.o:		png2dhgr.c
 			$(CC) $(CFLAGS) -c png2dhgr.c


### PR DESCRIPTION
Calls to $(CC) assumed that png.h, -lpng etc. were all in the default paths used by the compiler. However, this is not the case on some systems, such as MacOS using the MacPorts package system.

Add calls to pkg-config to add the appropriate paths to CFLAGS if necessary, and introduce LDFLAGS for linker library paths.

This assumes that pkg-config is available; it usually is (particularly on systems using GCC), but further work may be required if this is required to run on systems where it's not.

This also assumes Gnu Make; again further work may be required if this needs to be made compatible with Berkeley Make.

This has been tested on Debian 11 and on MacOS 10.14.6 with MacPorts 2.8.1