### PR TITLE
Makefile.inc: Use pkg-config to find libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ include Makefile.inc
 all:
 	cd utils && make
 
+show-config:
+	@echo "CFLAGS=${CFLAGS}"
+	@echo "LFLAGS=${LFLAGS}"
+
 install:
 	cd utils && make install
 

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,6 +1,5 @@
 CC = gcc
-CFLAGS = -O2 -Wall
-LFLAGS =
+CFLAGS = -O2 -Wall $(shell pkg-config --cflags libpng liblz4)
+LFLAGS = $(shell pkg-config --libs libpng liblz4)
 
 INSTALL_LOC = /usr/local/bin
-

--- a/utils/gr-utils/Makefile
+++ b/utils/gr-utils/Makefile
@@ -1,6 +1,6 @@
 include ../../Makefile.inc
 
-CFLAGS = -g -Wall -O2
+CFLAGS += -g
 
 all:	text2gr png2gr png2gr_text png2rle png2lz4 png_to_40x48d png_to_40x96 \
 	png2sixbitmap png2six80 png2sixrle png2fourrle png2sixrle2 png_16x16 \

--- a/utils/hgr-utils/Makefile
+++ b/utils/hgr-utils/Makefile
@@ -1,6 +1,6 @@
 include ../../Makefile.inc
 
-CFLAGS = -O2 -Wall -g
+CFLAGS += -g
 
 all:	pcx2hgr png2hgr png2dhgr shape_table dump_table \
 	hgr2png hgr_make_sprite png2font dhgr2png \


### PR DESCRIPTION
MacOS systems using MacPorts, among others, do not have libpng and liblz4 include files and libraries in the standard system paths; this ensures that wherever they are, they're added to the compiler and linker options.

(This requires that users have installed `pkg-config`, but most systems with development tools will have that already.)